### PR TITLE
Add Hover Transparency

### DIFF
--- a/module/styles/style.css
+++ b/module/styles/style.css
@@ -30,6 +30,9 @@
 	right: 0px;
 	z-index: 1000;
 }
+.typing-notify:hover {
+	opacity: 0.2
+}
 .typing-notify.hidden {
 	max-height: 0px;
 	color: transparent;


### PR DESCRIPTION
My players constantly voiced complaints about the notification covering their long-winded speeches and character interactions.
I already applied this to my game but making a PR here so if desired, it's applied for everyone. Otherwise, please see this as a suggestion to fix the issue of having 1/4 of the chat window go away anytime someone else types.