### PR TITLE
force chat in-character assigned

### DIFF
--- a/module/lang/en.json
+++ b/module/lang/en.json
@@ -5,6 +5,8 @@
 	"cgmp.blind-hidden-tokens-l": "Blind all rolls made by hidden tokens, only the GM can see them (chats are converted into visible Out of Character chats)",
 	"cgmp.disable-chat-recall-s": "Disable chat recalls",
 	"cgmp.disable-chat-recall-l": "Disable using up and down arrow keys to recall chats, so that they can be used to move the text cursor",
+	"cgmp.force-in-character-assigned-s": "Force all chat as assigned character",
+	"cgmp.force-in-character-assigned-l": "Chat messages will come from assigned character regardless of if that token is in the scene or if ooc chat is specified",
 	"cgmp.notify-typing-s": "Notify typing",
 	"cgmp.notify-typing-l": "Notify when other players are typing chat messages",
 	"cgmp.typing-one": "{user} is typing...", 

--- a/module/scripts/settings.js
+++ b/module/scripts/settings.js
@@ -12,9 +12,10 @@
  */
 
 export const CGMP_OPTIONS = {
-	DISABLE_GM_AS_PC: "disableGMAsPC",
 	BLIND_HIDDEN_TOKENS: "blindHiddenTokens",
 	DISABLE_CHAT_RECALL: "disableChatRecall",
+	DISABLE_GM_AS_PC: "disableGMAsPC",
+	FORCE_IN_CHARACTER_ASSIGNED: "forceInCharacterAssigned",
 	NOTIFY_TYPING: "notifyTyping"
 }
 
@@ -58,6 +59,16 @@ export class CGMPSettings {
 			default: false,
 			type: Boolean,
 			onChange: notifyTyping => window.location.reload()
+		});
+
+		game.settings.register("CautiousGamemastersPack", CGMP_OPTIONS.FORCE_IN_CHARACTER_ASSIGNED, {
+			name: "cgmp.force-in-character-assigned-s",
+			hint: "cgmp.force-in-character-assigned-l",
+			scope: "world",
+			config: true,
+			default: false,
+			type: Boolean,
+			onChange: forceInCharacterAssigned => window.location.reload()
 		});
 	}
 


### PR DESCRIPTION
Force all chat to player's assigned character, regardless of if their owned token is in the scene.

Ideally, this setting when checked would gray out the option for GM safe chat. Not sure how to do that though.

- Haven't updated module version
- Only EN text