### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/module/lang/fr.json
+++ b/module/lang/fr.json
@@ -18,5 +18,6 @@
 	"cgmp.hide-npc-damage-text-s": "Cacher le texte défilant des dégâts sur les jetons des PNJ",
 	"cgmp.hide-npc-healing-text-s": "Cacher le texte des soins défilant sur le jeton des PNJ",
 	"cgmp.gm-speaker-mode-s": "Mode GM orateur",
-	"cgmp.gm-speaker-mode-l": "\"Défaut\" : les orateurs ne sont pas modifiés. \"Désactiver le MJ parlant en tant que PJ\" : Toutes les discussions que le MJ prononce en tant que PJ sont des discussions hrp, à l'exception des jets. \"Forcer le personnage\" : Les messages de la conversation viendront du personnage assigné, que ce jeton soit dans la scène ou si conversation/ooc soit précisé. \"Toujours hors du personnage\" : Tous les messages sont hors du personnage "
+	"cgmp.gm-speaker-mode-l": "\"Défaut\" : les orateurs ne sont pas modifiés. \"Désactiver le MJ parlant en tant que PJ\" : Toutes les discussions que le MJ prononce en tant que PJ sont des discussions hrp, à l'exception des jets. \"Forcer le personnage\" : Les messages de la conversation viendront du personnage assigné, que ce jeton soit dans la scène ou si conversation/ooc soit précisé. \"Toujours hors du personnage\" : Tous les messages sont hors du personnage.\"Utiliser assigné si dans le personnage\":Identique à\"Forcer dans le personnage\",mais laisse seuls les messages du personnage.",
+	"cgmp.speaker-mode.in-character-always-assigned-s": "Utilisation assignée quand dans le personnage"
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Cautious Gamemaster's Pack/main](https://weblate.foundryvtt-hub.com/projects/CautiousGamemastersPack/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/CautiousGamemastersPack/-/main/horizontal-auto.svg)