### PR TITLE
fix: typing notifier compatibility with mobile improvements module

### DIFF
--- a/module/scripts/typing-notifier.js
+++ b/module/scripts/typing-notifier.js
@@ -24,7 +24,7 @@ export class TypingNotifier {
 
 	static typingUsers = new Map();
 
-	constructor(chatLogElement, allowPlayersToSeeTypingNotification) {
+	constructor(chatLogApp, chatLogElement, allowPlayersToSeeTypingNotification) {
 		this._lastPacketSent = null;
 		this._allowPlayersToSeeTypingNotification = allowPlayersToSeeTypingNotification;
 
@@ -39,7 +39,7 @@ export class TypingNotifier {
 
 		// If Mobile Improvements is enabled, then we need to use a wrapper for ChatLog._onChatKeyDown(),
 		// as clicking the send button does not generate a keydown event.
-		if (game.modules.get("mobile-improvements")?.active)
+		if (game.modules.get("mobile-improvements")?.active && !chatLogApp._original)
 			libWrapper.register('CautiousGamemastersPack', 'ChatLog.prototype._onChatKeyDown', this._onChatKeyDownWrapper.bind(this), 'WRAPPER');
 
 		const chatFormElement = chatLogElement.querySelector("#chat-form");
@@ -47,8 +47,7 @@ export class TypingNotifier {
 
 		this._chatBox = chatLogElement.querySelector("#chat-message");
 
-		if (!game.modules.get("mobile-improvements")?.active)
-			 this._chatBox.addEventListener("keydown", this._onChatKeyDown.bind(this));
+		this._chatBox.addEventListener("keydown", this._onChatKeyDown.bind(this));
 
 		this._charsPerLine = this._calcCharsPerLine();
 
@@ -226,7 +225,7 @@ export class TypingNotifierManager {
 		this._notifiers = new Map();
 
 		Hooks.on('renderChatLog', (chatLog, html, data) => {
-			this._notifiers[html[0]] = new TypingNotifier(html[0], this._allowPlayersToSeeTypingNotification);
+			this._notifiers[html[0]] = new TypingNotifier(chatLog, html[0], this._allowPlayersToSeeTypingNotification);
 		});
 
 		Hooks.on('closeChatLog', (chatLog, html, data) => {

--- a/module/scripts/typing-notifier.js
+++ b/module/scripts/typing-notifier.js
@@ -184,7 +184,9 @@ export class TypingNotifier {
 	}
 
 	_onChatKeyDownWrapper(wrapper, event) {
-		this._onChatKeyDown(event);
+		if (event.code === "Enter" && !event.shiftKey) {
+			this._emitTypingEnd();
+		}
 		wrapper(event);
 	}
 


### PR DESCRIPTION
Typing notifier previously wouldn't work with Mobile Improvements present because CGMP monkey patches ChatLog._onChatKeyDown but typing in the original chatbox doesn't call ChatLog._onChatKeyDown.
Solution: when Mobile Improvements is present, still listen to the chat box keydown event in addition to monkey patching _onChatKeyDown to see when the Mobile Improvements send button is pressed.

I identified this bug on Foundry v10 build 291 (latest stable release at the time of this pull request) with the dnd 5e system.